### PR TITLE
Tests against nightly version of php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 7.1
   - 7.2
+  - nightly
 
 env:
   matrix:


### PR DESCRIPTION
This PR updates the `.travis.yml` configuration testing your project against future versions of PHP.

**Motivation**: Don't allow introduce code that is not compatible with future versions of PHP.